### PR TITLE
Allow default values for joints

### DIFF
--- a/joint_dispatcher.orogen
+++ b/joint_dispatcher.orogen
@@ -29,6 +29,8 @@ task_context "Task" do
     # The output port names listed here must have a corresponding
     # OutputConfiguration entry in the outputs property
     property "dispatches", "std/vector</joint_dispatcher/SingleDispatchConfiguration>"
+    
+    property "defaultConfiguration", "std/vector</joint_dispatcher/DefaultJointConfiguration>"
 
     # Dynamic input port declaration for the inputs
     dynamic_input_port /\w+/, 'base/samples/Joints'

--- a/joint_dispatcherTypes.hpp
+++ b/joint_dispatcherTypes.hpp
@@ -39,6 +39,13 @@ namespace joint_dispatcher {
          */
         std::vector<std::string> output_selection_by_name;
     };
+    
+    struct DefaultJointConfiguration
+    {
+      std::string jointName;
+      
+      double position;
+    };
 }
 
 #endif

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,7 +1,7 @@
 <package>
   <description brief="oroGen integration of the joint dispatch functionality">
   </description>
-  <maintainer>Sylvain Joyeus/sylvain.joyeux@m4x.org</maintainer>
+  <maintainer>Janosch Machowinski/janosch.machowinski@dfki.de</maintainer>
   <license>LGPLv2 or later</license>
 
   <depend package="base/orogen/types" />

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -130,8 +130,8 @@ bool Task::startHook()
                     }
                 }
                 
-                if(found)
-                    break;
+                if(!found)
+                    continue;
                 
                 names.clear();
                 names.push_back(conf.jointName);

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -58,6 +58,7 @@ bool Task::configureHook()
         }
     }
 
+    std::map<std::string,std::string> jointToStreamMap;
     { // Now create the inputs *and* the dispatches at the same time
         vector<SingleDispatchConfiguration> config(_dispatches.get());
         for (size_t i = 0; i < config.size(); ++i)
@@ -89,6 +90,23 @@ bool Task::configureHook()
             out_sel.byName = conf.output_selection_by_name;
             out_sel.byIndex = conf.output_selection_by_index;
             mDispatcher.addDispatch(conf.input, in_sel, conf.output, out_sel);
+	    
+	    for(size_t j=0; j<conf.input_selection_by_name.size();j++)
+	    {
+		jointToStreamMap.insert(std::make_pair(conf.input_selection_by_name[j],conf.input));
+	    }
+        }
+    }
+    
+    { //Create default Configurations for joints
+	vector<DefaultJointConfiguration> config(_defaultConfiguration.get());
+	for (size_t i = 0; i < config.size(); ++i)
+        {
+	  DefaultJointConfiguration const& conf(config[i]);
+	  base::samples::Joints joints;
+	  joints.names.push_back(jointToStreamMap.at(conf.jointName));
+	  joints.elements.push_back(base::JointState::Position(conf.position));
+	  mDispatcher.write(jointToStreamMap.at(conf.jointName),joints);
         }
     }
     

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -110,17 +110,16 @@ bool Task::startHook()
         vector<DefaultJointConfiguration> config(_defaultConfiguration.get());
         for (size_t i = 0; i < config.size(); ++i)
         {
-            bool found = false;
             DefaultJointConfiguration const& conf(config[i]);
 
-            Output *out = NULL;
             for (size_t j = 0; j < mOutputPorts.size(); ++j)
             {
                 Dispatcher::ChannelID id = mDispatcher.getOutputByName(mOutputPorts[j]->getName());
                 
-                out = &(mDispatcher.getOutput(id)); 
+                Output &out(mDispatcher.getOutput(id)); 
                 
-                std::vector<std::string> names = out->getJointNames();
+                std::vector<std::string> names = out.getJointNames();
+                bool found = false;
 
                 for(size_t k = 0; k < names.size(); ++k)
                 {
@@ -133,17 +132,14 @@ bool Task::startHook()
                 
                 if(found)
                     break;
-            }
                 
-            if(!found)
-                throw std::runtime_error("Error, no joint " + conf.jointName + " found in configuration for default initalization");
-                
-            std::vector<std::string> names;
-            names.push_back(conf.jointName);
-                
-            std::vector<size_t> idx = out->mapJointNamesToIndex(names);
+                names.clear();
+                names.push_back(conf.jointName);
+                    
+                std::vector<size_t> idx = out.mapJointNamesToIndex(names);
 
-            out->updateJoint(idx[0], base::Time::now(), base::JointState::Position(conf.position));
+                out.updateJoint(idx[0], base::Time::now(), base::JointState::Position(conf.position));
+            }
         }
     }
     return true;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -58,7 +58,6 @@ bool Task::configureHook()
         }
     }
 
-    std::map<std::string,std::string> jointToStreamMap;
     { // Now create the inputs *and* the dispatches at the same time
         vector<SingleDispatchConfiguration> config(_dispatches.get());
         for (size_t i = 0; i < config.size(); ++i)
@@ -98,7 +97,16 @@ bool Task::configureHook()
         }
     }
     
-    { //Create default Configurations for joints
+
+    
+    return true;
+}
+bool Task::startHook()
+{
+    if (! TaskBase::startHook())
+        return false;
+
+    mDispatcher.reset();    { //Create default Configurations for joints
 	vector<DefaultJointConfiguration> config(_defaultConfiguration.get());
 	for (size_t i = 0; i < config.size(); ++i)
         {
@@ -109,15 +117,6 @@ bool Task::configureHook()
 	  mDispatcher.write(jointToStreamMap.at(conf.jointName),joints);
         }
     }
-    
-    return true;
-}
-bool Task::startHook()
-{
-    if (! TaskBase::startHook())
-        return false;
-
-    mDispatcher.reset();
     return true;
 }
 void Task::updateHook()

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -34,6 +34,8 @@ namespace joint_dispatcher {
 
         Dispatcher mDispatcher;
         base::samples::Joints mJoint;
+	
+	std::map<std::string,std::string> jointToStreamMap;
 
         /** Deletes all defined input and output ports */
         void clearPorts();


### PR DESCRIPTION
With this commit, it is possible, to set default
values for Joints, that have not reported values yet.
As soon, as a joint reports a value, the default 
is overwritten by it.
This is especially useful, if you have a robot, that 
is missing Joints due to repairs of a arm and you
want to fire up your motion control without big changes.
