### PR TITLE
for each dispatch, add a configuration option to defer writing to the…

### DIFF
--- a/joint_dispatcherTypes.hpp
+++ b/joint_dispatcherTypes.hpp
@@ -38,6 +38,12 @@ namespace joint_dispatcher {
          * select by index, use output_selection_by_index instead
          */
         std::vector<std::string> output_selection_by_name;
+               
+        /*
+         * If true, do not trigger immediate write
+         * to the output port, i.e. wait for another dispatch to do so
+         */
+        bool defer_output = false;
     };
     
     struct DefaultJointConfiguration

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -88,7 +88,7 @@ bool Task::configureHook()
             JointSelection out_sel;
             out_sel.byName = conf.output_selection_by_name;
             out_sel.byIndex = conf.output_selection_by_index;
-            mDispatcher.addDispatch(conf.input, in_sel, conf.output, out_sel);
+            mDispatcher.addDispatch(conf.input, in_sel, conf.output, out_sel, conf.defer_output);
 	    
 	    for(size_t j=0; j<conf.input_selection_by_name.size();j++)
 	    {


### PR DESCRIPTION
… output port immediately, i.e. to prevent updating the output port for each dispatch